### PR TITLE
Add linux support (GCC building)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+.editorconfig
+build/

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,41 @@
+## Linux Build Instructions
+
+### 1. Prerequisites
+
+To build this project on Linux, you will need `cmake`, a C compiler (aka `gcc`), and the zlib development headers.
+
+Install the dependencies based on your distribution:
+
+* **Debian / Ubuntu / Linux Mint:** `sudo apt install build-essential cmake zlib1g-dev`
+* **Fedora / RHEL / Rocky Linux:** `sudo dnf install gcc cmake zlib-devel`
+* **openSUSE:** `sudo zypper install gcc cmake zlib-devel`
+* **Arch Linux / Manjaro:** `sudo pacman -S base-devel cmake zlib`
+
+    *(For **CachyOS** users: CachyOS comes with zlib-ng installed, a zlib alternative. For zlib compatibility, `zlib-ng-compat` should already be installed. If it's not for some reason, you can install with `sudo pacman -S zlib-ng-compat`).*
+
+### 2. Building from Source
+Open your terminal in the root directory of the cloned repository. Run the following standard CMake commands to configure and compile the release binary:
+
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+```
+
+### 3. Running the Program
+
+Once the build is complete, the native gb2mid executable will be generated inside the build directory.
+
+**Important**: The program requires the GAMELIST.XML database to be in the same directory as the executable to function properly.
+
+Move the compiled binary back to the root directory where the XML file is located, and run it from there:
+
+```bash
+# Copy the binary to the root directory
+cp gb2mid ..
+cd ..
+
+# Extract MIDI files from the Game Boy file
+./gb2mid game.gb
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+project(GB2MID C)
+
+set(CMAKE_C_STANDARD 99)
+
+find_package(ZLIB REQUIRED)
+
+file(GLOB GBMLIB_SRC "GBMLIB/*.C" "GBMLIB/*.c")
+
+# Tell CMake these are C files
+set_source_files_properties(GB2MID.C ${GBMLIB_SRC} PROPERTIES LANGUAGE C)
+
+# GCC still reads .C (capital) as cpp so we need to force it to treat it as normal C
+set_source_files_properties(GB2MID.C ${GBMLIB_SRC} PROPERTIES COMPILE_FLAGS "-x c -fcommon")
+
+add_executable(gb2mid
+    GB2MID.C
+    ${GBMLIB_SRC}
+)
+
+target_include_directories(gb2mid PRIVATE GBMLIB)
+
+# Link against the system's zlib and math library (m)
+target_link_libraries(gb2mid PRIVATE ZLIB::ZLIB m)
+
+# Strip final binary to make it a true "Release" build
+set_target_properties(gb2mid PROPERTIES LINK_FLAGS "-s")

--- a/GB2MID.C
+++ b/GB2MID.C
@@ -16,9 +16,9 @@
 
 #define bankSize 16384
 FILE* rom, * mid, * xm, * mod, * txt, * raw, * wav, * cfg, *xml;
-int masterBank;
+long masterBank;
 int bank;
-int banks[50];
+long banks[50];
 char outfile[1000000];
 int songPtr;
 int songPtrs[4];
@@ -53,14 +53,14 @@ uint8_t* bankString;
 uint8_t* paramString;
 uint8_t* formatString;
 
-unsigned static char* romData;
-unsigned static char* fullRomData;
-unsigned static char* exRomData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
-unsigned static char* xmData;
-unsigned static char* modData;
-unsigned static char* headerBank;
+unsigned char* romData;
+unsigned char* fullRomData;
+unsigned char* exRomData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
+unsigned char* xmData;
+unsigned char* modData;
+unsigned char* headerBank;
 
 long midLength;
 long xmLength;

--- a/GBMLIB/ACT.C
+++ b/GBMLIB/ACT.C
@@ -1,7 +1,12 @@
 /*ACT Japan*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "ACT.H"
 
@@ -266,7 +271,11 @@ void ACTsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/AICOM.C
+++ b/GBMLIB/AICOM.C
@@ -1,7 +1,12 @@
 /*Aicom*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "AICOM.H"
 
@@ -332,7 +337,11 @@ void Aicomsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	for (j = 0; j < midLength; j++)

--- a/GBMLIB/AJG.C
+++ b/GBMLIB/AJG.C
@@ -1,7 +1,12 @@
 /*Alberto José González*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "AJG.H"
 

--- a/GBMLIB/ALLEYWAY.C
+++ b/GBMLIB/ALLEYWAY.C
@@ -1,7 +1,12 @@
 /*Nintendo - Unknown (Alleyway/Baseball)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "ALLEYWAY.H"
 

--- a/GBMLIB/ALTRON.C
+++ b/GBMLIB/ALTRON.C
@@ -1,7 +1,12 @@
 /*Altron*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "ALTRON.H"
 
@@ -172,7 +177,11 @@ void Altronsong2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/ARCHON.C
+++ b/GBMLIB/ARCHON.C
@@ -4,6 +4,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "ARCHON.H"
 
 #define bankSize 16384
@@ -121,7 +127,11 @@ void archOnsong2xm(int songNum, long songPtr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	xmLength = 0x40000;

--- a/GBMLIB/ATLUS.C
+++ b/GBMLIB/ATLUS.C
@@ -1,7 +1,12 @@
 /*Atlus (Tsukasa Masuko)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "ATLUS.H"
 
@@ -43,8 +48,8 @@ void Write8B(unsigned char* buffer, unsigned int value);
 void WriteBE32(unsigned char* buffer, unsigned long value);
 void WriteBE24(unsigned char* buffer, unsigned long value);
 void WriteBE16(unsigned char* buffer, unsigned int value);
-unsigned int WriteNoteEvent(unsigned static char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
-int WriteDeltaTime(unsigned static char* buffer, unsigned int pos, unsigned int value);
+unsigned int WriteNoteEvent(unsigned char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
+int WriteDeltaTime(unsigned char* buffer, unsigned int pos, unsigned int value);
 void Atlussong2mid(int songNum, long ptr);
 
 void AtlusProc(int bank)
@@ -184,7 +189,11 @@ void Atlussong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/AUDIOART.C
+++ b/GBMLIB/AUDIOART.C
@@ -1,7 +1,12 @@
 /*AudioArts*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "AUDIOART.H"
 
@@ -172,7 +177,7 @@ void AAProc(int bank)
 		}
 	}
 
-	if (tableOffset != NULL && seqOffset != NULL)
+	if (tableOffset != 0 && seqOffset != 0)
 	{
 		songNum = 1;
 		i = tableOffset;
@@ -180,7 +185,11 @@ void AAProc(int bank)
 		if (multiBanks != 0)
 		{
 			snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+			#ifdef _WIN32
 			_mkdir(folderName);
+			#else
+			mkdir(folderName, 0777);
+			#endif
 		}
 
 		if (format == 1)

--- a/GBMLIB/BEAM.C
+++ b/GBMLIB/BEAM.C
@@ -1,7 +1,12 @@
 /*Beam Software*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "BEAM.H"
 
@@ -32,9 +37,9 @@ long tempoTablePtrLoc;
 long tempoTableOffset;
 int songTempo;
 
-unsigned static char* romData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
+unsigned char* romData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
 
 long midLength;
 

--- a/GBMLIB/BGDEC.C
+++ b/GBMLIB/BGDEC.C
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+unsigned short ReadLE16(unsigned char* Data);
+
 #define bankSize 16384
 
 FILE* cmp, * bin;

--- a/GBMLIB/BIONIC.C
+++ b/GBMLIB/BIONIC.C
@@ -1,7 +1,12 @@
 /*Nintendo Software Technology (Bionic Commando: Elite Forces/Crystalis)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "BIONIC.H"
 

--- a/GBMLIB/BITS.C
+++ b/GBMLIB/BITS.C
@@ -1,7 +1,12 @@
 /*BITS/M4 (Shahid Ahmad)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "BITS.H"
 

--- a/GBMLIB/CANNON.C
+++ b/GBMLIB/CANNON.C
@@ -1,7 +1,12 @@
 /*Unknown PCM driver (Cannon Fodder)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CANNON.H"
 #include "WAV.H"

--- a/GBMLIB/CAPCOM.C
+++ b/GBMLIB/CAPCOM.C
@@ -1,7 +1,12 @@
 /*Capcom*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CAPCOM.H"
 
@@ -1448,7 +1453,11 @@ void Capsong2mid3(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/CARILLON.C
+++ b/GBMLIB/CARILLON.C
@@ -1,7 +1,12 @@
 /*Carillon Player (Aleski Eeben)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CARILLON.H"
 
@@ -26,9 +31,9 @@ int curBank;
 
 char folderName[100];
 
-unsigned static char* romData;
-unsigned static char* xmData;
-unsigned static char* endData;
+unsigned char* romData;
+unsigned char* xmData;
+unsigned char* endData;
 long xmLength;
 
 const unsigned int SongLocs[8] = { 0x00, 0x80, 0x40, 0xC0, 0x20, 0x60, 0xA0, 0xE0 };
@@ -144,7 +149,11 @@ void Carillonsong2xm(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	xmLength = 0x10000;

--- a/GBMLIB/CODEMONK.C
+++ b/GBMLIB/CODEMONK.C
@@ -1,7 +1,12 @@
 /*The Code Monkeys*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CODEMONK.H"
 

--- a/GBMLIB/COMPILE.C
+++ b/GBMLIB/COMPILE.C
@@ -1,7 +1,12 @@
 /*Compile*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "COMPILE.H"
 

--- a/GBMLIB/COSMIGO.C
+++ b/GBMLIB/COSMIGO.C
@@ -1,7 +1,12 @@
 /*Cosmigo*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "COSMIGO.H"
 
@@ -192,7 +197,11 @@ void Cosmigosong2xm(int songNum, long ptr, int numRows, int tempo, int volume)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	xmLength = 0x10000;

--- a/GBMLIB/CUBE.C
+++ b/GBMLIB/CUBE.C
@@ -3,7 +3,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CUBE.H"
 #include "BGDEC.H"
@@ -54,7 +59,7 @@ int WriteDeltaTime(unsigned char* buffer, unsigned int pos, unsigned int value);
 void Cubesong2mid(int songNum, long ptr);
 void copyDataCube(unsigned char* source, unsigned char* dest, long dataStart, long dataEnd);
 
-void CubeProc(int bank, char parameters[4][50])
+void CubeProc(int bank, char parameters[4][100])
 {
 	version = strtol(parameters[0], NULL, 16);
 
@@ -273,7 +278,11 @@ void Cubesong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/CUBE.H
+++ b/GBMLIB/CUBE.H
@@ -5,4 +5,4 @@
 #include <stddef.h>
 
 /*Function prototypes*/
-void CubeProc(int bank, char parameters[4][50]);
+void CubeProc(int bank, char parameters[4][100]);

--- a/GBMLIB/CULTRBRN.C
+++ b/GBMLIB/CULTRBRN.C
@@ -1,7 +1,12 @@
 /*Culture Brain*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "CULTRBRN.H"
 
@@ -269,7 +274,11 @@ void CBsong2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/DATAEAST.C
+++ b/GBMLIB/DATAEAST.C
@@ -1,7 +1,12 @@
 /*Data East*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DATAEAST.H"
 

--- a/GBMLIB/DAVDSHEA.C
+++ b/GBMLIB/DAVDSHEA.C
@@ -1,7 +1,12 @@
 /*David Shea (Coyote Developments)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DAVDSHEA.H"
 
@@ -159,7 +164,11 @@ void DShsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/DE1.C
+++ b/GBMLIB/DE1.C
@@ -1,7 +1,12 @@
 /*Digital Eclipse (Jeremy Sikas)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DE1.H"
 

--- a/GBMLIB/DKONG.C
+++ b/GBMLIB/DKONG.C
@@ -1,7 +1,12 @@
 /*Taisuke Araki (Donkey Kong/Wave Race/etc.)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DKONG.H"
 
@@ -298,7 +303,11 @@ void DKongsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/DSEQ.C
+++ b/GBMLIB/DSEQ.C
@@ -1,7 +1,12 @@
 /*DSEQ (Toshiyuki Ueno)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DSEQ.H"
 
@@ -201,7 +206,11 @@ void DSEQsong2mid(int songNum, long songPtrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/DUCKT.C
+++ b/GBMLIB/DUCKT.C
@@ -1,7 +1,12 @@
 /*Capcom (early - DuckTales 1)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DUCKT.H"
 
@@ -129,7 +134,7 @@ void DuckProc(int bank)
 				if (romData[songPtr - bankAmt] == 0x0F || romData[songPtr - bankAmt] == 0x07)
 				{
 					printf("Song %i: 0x%04X\n", songNum, songPtr);
-					song2mid(songNum, songPtr);
+					Ducksong2mid(songNum, songPtr);
 				}
 				else
 				{

--- a/GBMLIB/DW.C
+++ b/GBMLIB/DW.C
@@ -1,7 +1,12 @@
 /*David Whittaker*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "DW.H"
 
@@ -176,7 +181,11 @@ void DWsong2mid(int songNum, long ptrList[4], long nextPtr, int curSpeed)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	for (switchNum = 0; switchNum < 400; switchNum++)

--- a/GBMLIB/EASTRDGE.C
+++ b/GBMLIB/EASTRDGE.C
@@ -1,7 +1,12 @@
 /*Nick Eastridge*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "EASTRDGE.H"
 

--- a/GBMLIB/EDMAGNIN.C
+++ b/GBMLIB/EDMAGNIN.C
@@ -1,7 +1,12 @@
 /*Ed Magnin*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "EDMAGNIN.H"
 
@@ -163,7 +168,11 @@ void Magninsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/EHY.C
+++ b/GBMLIB/EHY.C
@@ -1,7 +1,12 @@
 /*Ei-How Yang (Sachen/Yong Yong (Makon Soft))*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include <math.h>
 #include "SHARED.H"
 #include "EHY.H"

--- a/GBMLIB/EQUIL.C
+++ b/GBMLIB/EQUIL.C
@@ -1,7 +1,12 @@
 /*Equilibrium*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "EQUIL.H"
 
@@ -44,8 +49,8 @@ void Write8B(unsigned char* buffer, unsigned int value);
 void WriteBE32(unsigned char* buffer, unsigned long value);
 void WriteBE24(unsigned char* buffer, unsigned long value);
 void WriteBE16(unsigned char* buffer, unsigned int value);
-unsigned int WriteNoteEvent(unsigned static char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
-int WriteDeltaTime(unsigned static char* buffer, unsigned int pos, unsigned int value);
+unsigned int WriteNoteEvent(unsigned char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
+int WriteDeltaTime(unsigned char* buffer, unsigned int pos, unsigned int value);
 void Equilsong2mid(int songNum, long ptr);
 
 void EquilProc(char parameters[4][100])

--- a/GBMLIB/FACTOR5.C
+++ b/GBMLIB/FACTOR5.C
@@ -1,7 +1,12 @@
 /*Factor 5 (early - Probotector 2/Animaniacs)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "FACTOR5.H"
 

--- a/GBMLIB/GAMEFRK.C
+++ b/GBMLIB/GAMEFRK.C
@@ -1,7 +1,12 @@
 /*Game Freak*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "GAMEFRK.H"
 
@@ -405,7 +410,11 @@ void GFsong2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/GEX.C
+++ b/GBMLIB/GEX.C
@@ -1,7 +1,12 @@
 /*FIRQ (Gex: Enter the Gecko)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "GEX.H"
 
@@ -159,7 +164,11 @@ void Gexsong2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/GHX.C
+++ b/GBMLIB/GHX.C
@@ -1,7 +1,12 @@
 /*GHX (Shin'en)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "GHX.H"
 
@@ -84,7 +89,7 @@ void GHXProc(int bank)
 					break;
 				}
 			}
-			if (headerOffset != NULL)
+			if (headerOffset != 0)
 			{
 				numSongs = romData[headerOffset - bankAmt + 3];
 				if (numSongs == 0)
@@ -183,7 +188,11 @@ void GHXsong2xm(int songNum, long info[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	xmLength = 0x10000;

--- a/GBMLIB/HAL.C
+++ b/GBMLIB/HAL.C
@@ -1,7 +1,12 @@
 /*HAL Laboratory*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "HAL.H"
 
@@ -415,7 +420,7 @@ void HALProc(int bank)
 	}
 	free(romData);
 	free(exRomData);
-	return 0;
+	return;
 }
 
 void HALsong2mid(int songNum, long ptr)
@@ -476,7 +481,11 @@ void HALsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/HUDSON.C
+++ b/GBMLIB/HUDSON.C
@@ -1,7 +1,12 @@
 /*Hudson Soft*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "HUDSON.H"
 
@@ -170,7 +175,11 @@ void HSsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/IMAGNRNG.C
+++ b/GBMLIB/IMAGNRNG.C
@@ -1,7 +1,12 @@
 /*Absolute/Imagineering*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "IMAGNRNG.H"
 

--- a/GBMLIB/JEROTEL.C
+++ b/GBMLIB/JEROTEL.C
@@ -1,7 +1,12 @@
 /*Jeroen Tel*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "JEROTEL.H"
 

--- a/GBMLIB/JSAITO.C
+++ b/GBMLIB/JSAITO.C
@@ -1,7 +1,12 @@
 /*Junichi Saito (Pack-in Video)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "JSAITO.H"
 

--- a/GBMLIB/KARMA.C
+++ b/GBMLIB/KARMA.C
@@ -1,7 +1,12 @@
 /*Karma Studios*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "KARMA.H"
 
@@ -92,7 +97,11 @@ void Karmasong2xm(int songNum, long songPtr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	xmLength = 0x10000;

--- a/GBMLIB/KEMCO.C
+++ b/GBMLIB/KEMCO.C
@@ -1,7 +1,12 @@
 /*Kemco*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "KEMCO.H"
 
@@ -301,7 +306,11 @@ void Kemcosong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;
@@ -1002,7 +1011,11 @@ void Kemcosong2midNES(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/KONAMI.C
+++ b/GBMLIB/KONAMI.C
@@ -1,7 +1,12 @@
 /*Konami*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "KONAMI.H"
 
@@ -564,7 +569,11 @@ void Konsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 

--- a/GBMLIB/KSADA.C
+++ b/GBMLIB/KSADA.C
@@ -1,7 +1,12 @@
 /*Kyouhei Sada (Pure Sound)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "KSADA.H"
 

--- a/GBMLIB/LUFIA.C
+++ b/GBMLIB/LUFIA.C
@@ -1,7 +1,12 @@
 /*Neverland (Lufia: The Legend Returns)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "LUFIA.H"
 

--- a/GBMLIB/MAKE.C
+++ b/GBMLIB/MAKE.C
@@ -1,7 +1,12 @@
 /*Make Software*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MAKE.H"
 
@@ -313,7 +318,11 @@ void Makesong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/MARBLE.C
+++ b/GBMLIB/MARBLE.C
@@ -1,7 +1,12 @@
 /*Unknown (Marble Madness (GB)) - Nick Eastridge variant?*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MARBLE.H"
 

--- a/GBMLIB/MCOOKSEY.C
+++ b/GBMLIB/MCOOKSEY.C
@@ -1,7 +1,12 @@
 /*Mark Cooksey*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MCOOKSEY.H"
 
@@ -317,7 +322,7 @@ void MCProc(int bank)
 
 	}
 
-	if (tableOffset != NULL)
+	if (tableOffset != 0)
 	{
 		songNum = 1;
 		if (sysMode == 1)
@@ -526,7 +531,11 @@ void MCsong2mid(int songNum, long ptrs[], long nextPtr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;
@@ -1246,7 +1255,7 @@ void MCgetMacroList(unsigned long list[], long offset, long sfxTable)
 				tempCurValue = (ReadLE16(&romData[newOffset + 2 - bankAmt]));
 				if (tempCurValue == 10794)
 				{
-					list[j] = NULL;
+					list[j] = 0;
 					highestMacro = j - 1;
 					break;
 				}

--- a/GBMLIB/MEGAMAN1.C
+++ b/GBMLIB/MEGAMAN1.C
@@ -5,7 +5,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MEGAMAN1.H"
 
@@ -57,9 +62,9 @@ unsigned int WriteNoteEvent(unsigned char* buffer, unsigned int pos, unsigned in
 int WriteDeltaTime(unsigned char* buffer, unsigned int pos, unsigned int value);
 void MM1song2mid(int songNum, long ptr);
 
-unsigned static char* romData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
+unsigned char* romData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
 
 long midLength;
 
@@ -197,7 +202,11 @@ void MM1song2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/MEGAMAN2.C
+++ b/GBMLIB/MEGAMAN2.C
@@ -2,7 +2,12 @@
 /*Also works with other games with audio by Giraffe Soft*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MEGAMAN2.H"
 
@@ -31,9 +36,9 @@ int curInst;
 int compatibility;
 int octaveSet;
 
-unsigned static char* romData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
+unsigned char* romData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
 
 long midLength;
 

--- a/GBMLIB/MEGAMAN3.C
+++ b/GBMLIB/MEGAMAN3.C
@@ -1,7 +1,12 @@
 /*Kouji Murata (Mega Man 3-5/Bionic Commando)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MEGAMAN3.H"
 
@@ -201,7 +206,11 @@ void song2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/METROID2.C
+++ b/GBMLIB/METROID2.C
@@ -1,7 +1,12 @@
 /*Nintendo (Ryohji Yoshitomi) (Metroid 2/Wario Land 1)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "METROID2.H"
 

--- a/GBMLIB/MMSS.C
+++ b/GBMLIB/MMSS.C
@@ -1,7 +1,12 @@
 /*M.M.S.S. (Multi Music Sound System) - Meldac/KAZe*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MMSS.H"
 
@@ -450,7 +455,11 @@ void MMSSsong2mid(int songNum, long songPtrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/MPLAY.C
+++ b/GBMLIB/MPLAY.C
@@ -1,7 +1,12 @@
 /*MPlay (Thomas E. Petersen)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MPLAY.H"
 

--- a/GBMLIB/MUSYX.C
+++ b/GBMLIB/MUSYX.C
@@ -1,7 +1,12 @@
 /*MusyX (Factor 5)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MUSYX.H"
 #include "WAV.H"
@@ -686,7 +691,7 @@ void sam2wav(int sampNum, long ptr, long size, int bank, int quality)
 	int sampleRate = 8192;
 	unsigned char lowNibble = 0;
 	unsigned char highNibble = 0;
-	unsigned static char* rawData;
+	unsigned char* rawData;
 	int rawLength = 0x100000;
 
 	sprintf(outfile2, "sample%i.wav", sampNum);

--- a/GBMLIB/MWALKER.C
+++ b/GBMLIB/MWALKER.C
@@ -2,7 +2,12 @@
 /*For Metal Walker, see TOSE.*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "MWALKER.H"
 
@@ -51,9 +56,9 @@ unsigned long seqList[500];
 unsigned long chanPts[3];
 int totalSeqs;
 
-unsigned static char* romData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
+unsigned char* romData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
 
 long midLength;
 
@@ -371,7 +376,11 @@ void MWsong2mid(int songNum, long ptrs[4], long nextPtr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	for (switchNum = 0; switchNum < 400; switchNum++)

--- a/GBMLIB/NAMCO.C
+++ b/GBMLIB/NAMCO.C
@@ -1,7 +1,12 @@
 /*Namco*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NAMCO.H"
 

--- a/GBMLIB/NATSUME.C
+++ b/GBMLIB/NATSUME.C
@@ -1,7 +1,12 @@
 /*Natsume*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NATSUME.H"
 
@@ -156,7 +161,11 @@ void Natsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/NBALDWIN.C
+++ b/GBMLIB/NBALDWIN.C
@@ -1,7 +1,12 @@
 /*Neil Baldwin (Eurocom)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NBALDWIN.H"
 

--- a/GBMLIB/NINTENDO.C
+++ b/GBMLIB/NINTENDO.C
@@ -1,7 +1,12 @@
 /*Nintendo (Hirokazu Tanaka)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NINTENDO.H"
 
@@ -25,9 +30,9 @@ int highestSeq;
 int curVol;
 int endList = 0;
 int curStepTab[16];
-unsigned static char* romData;
-unsigned static char* midData;
-unsigned static char* ctrlMidData;
+unsigned char* romData;
+unsigned char* midData;
+unsigned char* ctrlMidData;
 unsigned long seqList[30];
 unsigned long patList[30];
 unsigned long songList[90];
@@ -401,7 +406,11 @@ void Nintsong2mid(int songNum, long ptrList[4], long speedPtr, int songTrans)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/NOVA.C
+++ b/GBMLIB/NOVA.C
@@ -1,7 +1,12 @@
 /*Nova/Arc System Works*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NOVA.H"
 
@@ -485,7 +490,11 @@ void Novasong2mid(int songNum, long ptr, int songBank)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/NOWPRO.C
+++ b/GBMLIB/NOWPRO.C
@@ -1,7 +1,12 @@
 /*Now Production/Music Worx*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "NOWPRO.H"
 
@@ -230,7 +235,11 @@ void Nowsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/OCEAN.C
+++ b/GBMLIB/OCEAN.C
@@ -1,7 +1,12 @@
 /*Ocean (Jonathan Dunn)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "OCEAN.H"
 
@@ -246,7 +251,7 @@ void OcnProc(int bank)
 	}
 
 
-	if (tableOffset != NULL)
+	if (tableOffset != 0)
 	{
 		songNum = 1;
 		i = tableOffset;
@@ -404,7 +409,11 @@ void Ocnsong2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midPos = 0;

--- a/GBMLIB/PARAGON5.C
+++ b/GBMLIB/PARAGON5.C
@@ -1,7 +1,12 @@
 /*Paragon 5*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "PARAGON5.H"
 
@@ -204,7 +209,11 @@ void P5song2xm(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	for (l = 0; l < xmLength; l++)

--- a/GBMLIB/PBOX.C
+++ b/GBMLIB/PBOX.C
@@ -1,7 +1,12 @@
 /*Pandora Box*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "PBOX.H"
 #include "PBDEC.H"

--- a/GBMLIB/PROBE.C
+++ b/GBMLIB/PROBE.C
@@ -1,7 +1,12 @@
 /*Probe Software*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "PROBE.H"
 

--- a/GBMLIB/RARE.C
+++ b/GBMLIB/RARE.C
@@ -1,7 +1,12 @@
 /*RARE*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "RARE.H"
 

--- a/GBMLIB/REALTIME.C
+++ b/GBMLIB/REALTIME.C
@@ -1,7 +1,12 @@
 /*Realtime Associates (David Warhol)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "REALTIME.H"
 
@@ -206,7 +211,11 @@ void RTAsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/RNC.C
+++ b/GBMLIB/RNC.C
@@ -9,7 +9,12 @@
 #ifndef _WIN32
 #include <sys/stat.h>
 #else
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #define mkdir(name, mode) mkdir(name)
 #endif
 

--- a/GBMLIB/ROLAN.C
+++ b/GBMLIB/ROLAN.C
@@ -1,7 +1,12 @@
 /*NMK (Rolan's Curse 1/2/Ninja Taro)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "ROLAN.H"
 

--- a/GBMLIB/SAFFIRE.C
+++ b/GBMLIB/SAFFIRE.C
@@ -1,7 +1,12 @@
 /*Saffire*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SAFFIRE.H"
 

--- a/GBMLIB/SCULPT.C
+++ b/GBMLIB/SCULPT.C
@@ -1,7 +1,12 @@
 /*Sculptured Software*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SCULPT.H"
 

--- a/GBMLIB/SHEEP.C
+++ b/GBMLIB/SHEEP.C
@@ -1,7 +1,12 @@
 /*Sheep - Manabu Namiki (Doki X Doki Sasete)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SHEEP.H"
 
@@ -149,7 +154,11 @@ void Sheepsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/SQUARE.C
+++ b/GBMLIB/SQUARE.C
@@ -1,7 +1,12 @@
 /*Square*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SQUARE.H"
 

--- a/GBMLIB/SQZDEC.C
+++ b/GBMLIB/SQZDEC.C
@@ -24,6 +24,7 @@ int decompPos;
 unsigned char* compData;
 unsigned char* decompData;
 
+unsigned short ReadLE16(unsigned char* Data);
 unsigned short ReadLE162(unsigned char* Data);
 
 /*Convert little-endian pointer to big-endian*/
@@ -130,7 +131,7 @@ void UnSQZ(unsigned char* compData, unsigned char* decompData, long compLength)
             if (dict_character != NULL)
                 free(dict_character);
             printf("ERROR: Insufficient memory!\n");
-            return (-2);
+            return;
         }
 
         while ((k_pos < compLength) && (out_pos < decmpSize)) {
@@ -168,7 +169,7 @@ void UnSQZ(unsigned char* compData, unsigned char* decompData, long compLength)
                             free(dict_prefix);
                             free(dict_character);
                             printf("ERROR: Invalid file!\n");
-                            return (-1);
+                            return;
                         }
                     }
                     dict_stack[i++] = tmp_k;
@@ -191,7 +192,7 @@ void UnSQZ(unsigned char* compData, unsigned char* decompData, long compLength)
                         {
                             free(dict_prefix);
                             free(dict_character);
-                            return (-1);
+                            return;
                         }
                     }
                     dict_stack[i++] = tmp_k;

--- a/GBMLIB/SUNSOFT.C
+++ b/GBMLIB/SUNSOFT.C
@@ -1,7 +1,12 @@
 /*Sunsoft*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SUNSOFT.H"
 
@@ -170,7 +175,11 @@ void SSsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	for (j = 0; j < midLength; j++)

--- a/GBMLIB/SWC1.C
+++ b/GBMLIB/SWC1.C
@@ -1,7 +1,12 @@
 /*Software Creations 1 (by Stephen Ruddy)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SWC1.H"
 

--- a/GBMLIB/SWC2.C
+++ b/GBMLIB/SWC2.C
@@ -1,7 +1,12 @@
 /*Software Creations 2 (by Paul Tonge?)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "SWC2.H"
 
@@ -156,7 +161,11 @@ void SWC2song2mid(int songNum, long ptrs[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/TAITO.C
+++ b/GBMLIB/TAITO.C
@@ -1,7 +1,12 @@
 /*Taito*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "TAITO.H"
 

--- a/GBMLIB/TARANTLA.C
+++ b/GBMLIB/TARANTLA.C
@@ -1,7 +1,12 @@
 /*Tarantula Studios*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "TARANTLA.H"
 
@@ -177,7 +182,11 @@ void Tarantulasong2mid(int songNum, long ptrs[4], int banks[4])
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/TECHNOS.C
+++ b/GBMLIB/TECHNOS.C
@@ -1,7 +1,12 @@
 /*Technos Japan*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "TECHNOS.H"
 
@@ -204,7 +209,11 @@ void TJsong2mid(int songNum, long ptr)
 	if (multiBanks != 0)
 	{
 		snprintf(folderName, sizeof(folderName), "Bank %i", (curBank + 1));
+		#ifdef _WIN32
 		_mkdir(folderName);
+		#else
+		mkdir(folderName, 0777);
+		#endif
 	}
 
 	midLength = 0x10000;

--- a/GBMLIB/TIERTEX.C
+++ b/GBMLIB/TIERTEX.C
@@ -1,7 +1,12 @@
 /*Tiertex*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "TIERTEX.H"
 
@@ -86,7 +91,7 @@ void TTProc(int bank, char parameters[4][100])
 			break;
 		}
 	}
-	if (tableOffset != NULL)
+	if (tableOffset != 0)
 	{
 		if (oldMode == 0)
 		{

--- a/GBMLIB/TITUS1.C
+++ b/GBMLIB/TITUS1.C
@@ -1,7 +1,12 @@
 /*Titus (early driver)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "TITUS1.H"
 

--- a/GBMLIB/TITUSDEC.C
+++ b/GBMLIB/TITUSDEC.C
@@ -21,8 +21,8 @@ long cmpSize;
 long decmpSize;
 int counter;
 int mask;
-CPU mask1 = { 0, 0 };
-CPU mask2 = { 0, 0 };
+static CPU mask1 = { 0, 0 };
+static CPU mask2 = { 0, 0 };
 int compPos;
 int decompPos;
 int carry;
@@ -57,6 +57,7 @@ unsigned short ReadBE162(unsigned char* Data)
 
 void TitusDecomp(unsigned char* compData, unsigned char* decompData, long compLen)
 {
+	int endData = 0;
 	tempByte = 0;
 	tempByteFF = 0;
 	bytesCopy = 0;
@@ -191,7 +192,7 @@ void TitusDecomp(unsigned char* compData, unsigned char* decompData, long compLe
 
 	}
 
-	return 0;
+	return;
 
 Method20E6:
 	/*CALL $2162*/

--- a/GBMLIB/TOSE.C
+++ b/GBMLIB/TOSE.C
@@ -1,7 +1,12 @@
 /*TOSE*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 
 #include <stdlib.h>

--- a/GBMLIB/UGB.C
+++ b/GBMLIB/UGB.C
@@ -1,7 +1,12 @@
 /*UGB Player (by Thalamus/Jon Wells)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "UGB.H"
 
@@ -19,7 +24,7 @@ long bankAmt;
 int curInst;
 int drvVers;
 int curVol;
-int masterBank;
+long masterBank;
 int songBank;
 int songIndex;
 int speed1;
@@ -53,10 +58,10 @@ void Write8B(unsigned char* buffer, unsigned int value);
 void WriteBE32(unsigned char* buffer, unsigned long value);
 void WriteBE24(unsigned char* buffer, unsigned long value);
 void WriteBE16(unsigned char* buffer, unsigned int value);
-unsigned int WriteNoteEvent(unsigned static char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
+unsigned int WriteNoteEvent(unsigned char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
 unsigned int WriteNoteEventOn(unsigned char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
 unsigned int WriteNoteEventOff(unsigned char* buffer, unsigned int pos, unsigned int note, int length, int delay, int firstNote, int curChan, int inst);
-int WriteDeltaTime(unsigned static char* buffer, unsigned int pos, unsigned int value);
+int WriteDeltaTime(unsigned char* buffer, unsigned int pos, unsigned int value);
 void UGBsong2mid(int songNum);
 
 void UGBProc(char parameters[4][100])

--- a/GBMLIB/WARIOL2.C
+++ b/GBMLIB/WARIOL2.C
@@ -1,7 +1,12 @@
 /*Nintendo (Kozue Ishikawa) (Wario Land 2/3)*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "WARIOL2.H"
 

--- a/GBMLIB/WINKYSFT.C
+++ b/GBMLIB/WINKYSFT.C
@@ -1,7 +1,12 @@
 /*Winkysoft*/
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 #include "SHARED.H"
 #include "WINKYSFT.H"
 


### PR DESCRIPTION
This PR adds linux support (aka successful building with GCC).
---
Aside from the standard cmake additions here for building and the `#include` additions to use `mkdir` instead of `_mkdir` when on linux, I had to modify a lot of the C files in order to get them to build with GCC; It seems it's a lot more strict on C rules than Microsoft's MSVC... Main changes include changing `NULL` to `0` in comparisons (GCC doesn't like comparing pointer (NULL) with integer). The other main change is replacing `return(number)` with just `return` in void functions (can't return a value).

Also, historically .C (capital C) has been used for cpp source files (Why? no clue). On Windows this isn't really an issue since there's no case sensitivity - however on Linux with GCC, it reads them as cpp files so I had to force it in CMake.

I realize that this is quite a large change and would disrupt your workflow - I know GCC is a lot more strict with C standards and rules than MSVC is so if you don't want to accept this PR I fully understand. Mainly sharing this in the hopes that it helps others who are wanting to build and run this amazing program on Linux like me :)

Would also like to note that by using something like **MSYS2**, you could install `mingw-w64-x86_64-gcc`, `zlib`, and `cmake` through it and use cmake to successfully build this program on Windows as well! (Would solve the debug-only issue caused by the old zlib.lib library)

(Tested and fully working on my machine. Checked with multiple random supported roms and seems to extract just fine, although I **cannot confirm** if these changes break anything on Windows as I don't have access to a Windows machine nor Visual Studio).